### PR TITLE
🐛 [버그 수정] : DB테이블 자동 생성 설정 삭제 - 쿼리문으로 수동 생성

### DIFF
--- a/podman-compose.yaml
+++ b/podman-compose.yaml
@@ -39,7 +39,7 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:mariadb://mariadb:3307/bookcalendar
       - SPRING_DATASOURCE_USERNAME=bookcalendar
       - SPRING_DATASOURCE_PASSWORD=bookcalendar123
-      - SPRING_JPA_HIBERNATE_DDL_AUTO=update
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=none
       - SPRING_JPA_SHOW_SQL=true
       - LOGGING_LEVEL_ROOT=INFO
       - LOGGING_LEVEL_ORG_HIBERNATE=INFO


### PR DESCRIPTION
springboot 컨테이너에서  SPRING_JPA_HIBERNATE_DDL_AUTO=update를  SPRING_JPA_HIBERNATE_DDL_AUTO=none로 변환