### PR TITLE
⚡️ [성능 개선] : Fast-API 서버 다운 대응

### DIFF
--- a/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Controller/ChatBotController.java
+++ b/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Controller/ChatBotController.java
@@ -46,10 +46,10 @@ public class ChatBotController {
     public ResponseEntity<ApiResponseWrapper<String>> chat(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                           @RequestBody ChatRequest chatRequest) {
 
-        // Fast-API 서버 ChatBot AI 연결 서비스 레이어 호출
-        // String aiResponse = chatbotService.aiChat(customUserDetails, chatRequest);
+        // 향상된 챗봇 채팅 서비스 레이어 호출
+        String aiResponse = chatbotService.enhancedChat(customUserDetails, chatRequest);
         // 챗봇 채팅 서비스 레이어 호출
-        String aiResponse = chatbotService.chat(customUserDetails, chatRequest);
+        // String aiResponse = chatbotService.chat(customUserDetails, chatRequest);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new ApiResponseWrapper<>(aiResponse, "채팅 메시지가 정상적으로 전송/반환되었습니다."));

--- a/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Helper/ChatBotHelper.java
+++ b/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Helper/ChatBotHelper.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class RedisHelper {
+public class ChatBotHelper {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Manager/ChatBotManager.java
+++ b/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Manager/ChatBotManager.java
@@ -1,7 +1,7 @@
 package bookcalendar.server.Domain.ChatBot.Manager;
 
 import bookcalendar.server.Domain.Book.DTO.Response.CompleteResponse;
-import bookcalendar.server.Domain.ChatBot.Helper.RedisHelper;
+import bookcalendar.server.Domain.ChatBot.Helper.ChatBotHelper;
 import bookcalendar.server.Domain.Member.Entity.Member;
 import bookcalendar.server.Domain.Member.Exception.MemberException;
 import bookcalendar.server.Domain.Member.Repository.MemberRepository;
@@ -16,8 +16,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +24,7 @@ import java.util.Set;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class RedisManager {
+public class ChatBotManager {
 
     @Qualifier("sessionRedisTemplate")
     @Autowired
@@ -191,13 +189,13 @@ public class RedisManager {
     public String getTopic(String everyMessages) {
 
         /* Helper 클래스에서 Gpt 프롬프팅 */
-        String promptedMessage = RedisHelper.buildPrompt_getTopic(everyMessages);
+        String promptedMessage = ChatBotHelper.buildPrompt_getTopic(everyMessages);
 
         /* Gpt 호출 */
         String topicsResponseByGpt = chatClient.call(promptedMessage);
 
         /* 데이터 파싱 */
-        String topic = RedisHelper.parseTopic(topicsResponseByGpt);
+        String topic = ChatBotHelper.parseTopic(topicsResponseByGpt);
 
         /* 로그 출력 */
         log.info("추출한 주제 : {}", topic);

--- a/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Service/ChatbotService.java
+++ b/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Service/ChatbotService.java
@@ -10,23 +10,36 @@ import java.util.List;
 
 public interface ChatbotService {
 
+    /**
+     * 향상된 챗봇 서비스 인터페이스
+     *
+     * 1. Redis-Session에 fastapi관련 에러기록이 있는지 확인
+     * 2. 에러 기록 없으면 fastapi 호출 || 에러 기록 있으면 바로 Gpt 모델로 연결
+     * 3. fastapi 호출간에 에러 반환 시, Gpt호출 && Redis에 보고 && fastapi 재시작 명령어 호출
+     *
+     * @param customUserDetails 인증된 유저의 정보 객체
+     * @param chatRequest 클라이언트의  채팅 내용
+     * @return 답변 내용
+     */
+    String enhancedChat(CustomUserDetails customUserDetails, ChatRequest chatRequest);
+
     /* AI 챗봇 모델 연결 인터페이스 */
-    String aiChat(CustomUserDetails customUserDetails, ChatRequest chatRequest);
+    // String aiChat(CustomUserDetails customUserDetails, ChatRequest chatRequest);
 
     /**
      * 챗봇 채팅 인터페이스
      *
-     * @param customUserDetails
-     * @param chatRequest
-     * @return
+     * @param customUserDetails 인증된 유저의 정보 객체
+     * @param chatRequest 채팅 내용
+     * @return 답변 내용
      */
     String chat(CustomUserDetails customUserDetails, ChatRequest chatRequest);
 
     /**
      * 도서 추천 인터페이스
      *
-     * @param customUserDetails
-     * @return
+     * @param customUserDetails 인증된 유저의 정보 객체
+     * @return 추천 도서 리스트
      */
     List<CompleteResponse> recommend(CustomUserDetails customUserDetails);
 

--- a/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Service/ChatbotServiceImpl.java
+++ b/springboot/src/main/java/bookcalendar/server/Domain/ChatBot/Service/ChatbotServiceImpl.java
@@ -1,37 +1,32 @@
 package bookcalendar.server.Domain.ChatBot.Service;
 
 import bookcalendar.server.Domain.Book.DTO.Response.CompleteResponse;
-import bookcalendar.server.Domain.ChatBot.DTO.Request.SaveBookRequest;
-import bookcalendar.server.Domain.ChatBot.Manager.RedisManager;
 import bookcalendar.server.Domain.ChatBot.DTO.Request.ChatRequest;
-import bookcalendar.server.Domain.ChatBot.Helper.RedisHelper;
+import bookcalendar.server.Domain.ChatBot.DTO.Request.SaveBookRequest;
+import bookcalendar.server.Domain.ChatBot.Helper.ChatBotHelper;
+import bookcalendar.server.Domain.ChatBot.Manager.ChatBotManager;
 import bookcalendar.server.Domain.Member.Entity.Member;
 import bookcalendar.server.Domain.Member.Exception.MemberException;
 import bookcalendar.server.Domain.Member.Repository.MemberRepository;
 import bookcalendar.server.Domain.Mypage.Entity.Cart;
 import bookcalendar.server.Domain.Mypage.Repository.CartRepository;
-import bookcalendar.server.global.BookOpenApi.Aladin.AladinResponse;
-import bookcalendar.server.global.BookOpenApi.Aladin.AladinService;
-import bookcalendar.server.global.BookOpenApi.NationalCentralLibrary.NationalCentralLibraryResponse;
-import bookcalendar.server.global.BookOpenApi.NationalCentralLibrary.NationalCentralLibraryService;
-import bookcalendar.server.global.BookOpenApi.Naver.NaverResponse;
-import bookcalendar.server.global.BookOpenApi.Naver.NaverService;
 import bookcalendar.server.global.ExternalConnection.Client.IntentClient;
 import bookcalendar.server.global.Security.CustomUserDetails;
 import bookcalendar.server.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -39,19 +34,78 @@ import java.util.stream.Collectors;
 public class ChatbotServiceImpl implements ChatbotService{
 
     private final ChatClient chatClient;
-    private final RedisManager redisManager;
+    private final ChatBotManager chatBotManager;
     private final MemberRepository memberRepository;
     private final CartRepository cartRepository;
     private final IntentClient intentClient;
 
+    @Qualifier("sessionRedisTemplate")
+    private final RedisTemplate<String, String> sessionRedisTemplate;
+
    // ======================= AI 채팅 로직 =========================
 
-    /* Fast-API 서버 AI 챗봇 채팅 로직 */
+    /* 향상된 채팅 서비스 - fastapi와 gpt 혼용*/
     @Override
-    public String aiChat(CustomUserDetails customUserDetails, ChatRequest chatRequest) {
+    public String enhancedChat(CustomUserDetails customUserDetails, ChatRequest chatRequest) {
 
-        String aiResponse = intentClient.predict(chatRequest.chatMessage()).block(); // fast-api 서버의 ai 챗봇 모델 호출
-        redisManager.saveMessageInRedis(customUserDetails.getMemberId(), chatRequest.chatMessage(),aiResponse); // 유저 메시지,챗봇 답변 Redis에 업로드
+     /* 1. Redis-Session에 fastapi관련 에러기록이 있는지 확인 */
+
+        // Redis-Session에 fastapi 관련 에러 기록이 있는지 확인
+        String redisKey = "FastAPI-Error";
+        String aiResponse;
+        String errorFlag = sessionRedisTemplate.opsForValue().get(redisKey);
+
+     /* 2. 에러 기록 없으면 fastapi 호출 || 에러 기록 있으면 바로 Gpt 모델로 연결 */
+
+        // Fast- API서버 다운 시 Gpt 모델 호출
+        if (errorFlag != null) {
+            log.info("fastapi 오류 기록 확인 {}, Gpt모델로 임시 대체", errorFlag);
+
+            String previousMessage  = chatBotManager.getPreviousMessage(customUserDetails.getMemberId()); // Redis DB에서 기존의 대화내용이 있으면 반환
+            String promptMessage = ChatBotHelper.makePromptMessage(chatRequest.chatMessage(), previousMessage); // 사용자 메시지를 프롬프팅
+            String rawAiResponse = chatClient.call(promptMessage); // 프로프팅한 유저의 채팅에 대한 AI 상담사 챗봇 답변 반환
+            aiResponse = ChatBotHelper.textCleaner(rawAiResponse); // AI 상담사 챗봇의 답변에 불순물 제거
+        }else{
+            // 3. FastAPI 시도 → 실패 시 GPT 호출 및 Redis에 에러 기록 (TTL 30분)
+            try {
+                aiResponse = intentClient.predict(chatRequest.chatMessage()).block();
+            } catch (Exception e) {
+     /* 3. fastapi 호출간에 에러 반환 시, Gpt호출 && Redis에 보고 && fastapi 재시작 명령어 호출 */
+
+                log.info("FastAPI 예외 발생 & Gpt모델 호출 전환 - Fast-API 에러메시지 :{}", e.getMessage());
+
+                // todo : get errorTime
+                // 에러 발생 시간을 에러키의 Value로 대입
+                LocalDateTime errorTime = LocalDateTime.now();
+                String errorTimeStr = errorTime.toString();
+
+                // Redis에 FastAPI 오류 보고 (TTL: 30분)
+                sessionRedisTemplate.opsForValue().set(redisKey, errorTimeStr, Duration.ofMinutes(30));
+
+                // Gpt 모델 호출
+                String previousMessage = chatBotManager.getPreviousMessage(customUserDetails.getMemberId());
+                String promptMessage = ChatBotHelper.makePromptMessage(chatRequest.chatMessage(), previousMessage);
+                String rawAiResponse = chatClient.call(promptMessage);
+                aiResponse = ChatBotHelper.textCleaner(rawAiResponse);
+
+                // todo : reRunFast-API
+                // fast-api 재시작 명령어 가동
+                // 이 명령을 bash script로 만들어 놓고, Java에서 sh restart_fastapi.sh 실행하도록 해도 관리가 더 편리할 수 있을 것 같음.
+                try {
+                    ProcessBuilder builder = new ProcessBuilder(
+                            "sh", "-c", "uvicorn main:app --host 0.0.0.0 --port 3004 --reload"
+                    );
+                    builder.directory(new File("/home/t25101/v0.5/ai/BookCalendar-AI")); // FastAPI가 위치한 디렉토리
+                    builder.start();
+                    log.info("FastAPI 재시작 명령 실행 완료");
+                } catch (IOException e2) {
+                    log.info("FastAPI 재시작 실패", e2);
+                }
+            }
+        }
+
+        // 유저 메시지,챗봇 답변 Redis에 업로드
+        chatBotManager.saveMessageInRedis(customUserDetails.getMemberId(), chatRequest.chatMessage(), aiResponse);
 
         return aiResponse;
     }
@@ -60,15 +114,29 @@ public class ChatbotServiceImpl implements ChatbotService{
     @Override
     public String chat(CustomUserDetails customUserDetails, ChatRequest chatRequest) {
 
-        String previousMessage  = redisManager.getPreviousMessage(customUserDetails.getMemberId()); // Redis DB에서 기존의 대화내용이 있으면 반환
-        String promptMessage = RedisHelper.makePromptMessage(chatRequest.chatMessage(), previousMessage); // 사용자 메시지를 프롬프팅
-        String aiResponse = chatClient.call(promptMessage); // 프로프팅한 유저의 채팅에 대한 AI 상담사 챗봇 답변 반환
-        String cleanAiResponse = RedisHelper.textCleaner(aiResponse); // AI 상담사 챗봇의 답변에 불순물 제거
+        /* Fast-API 챗봇 AI 호출 */
+        // String aiResponse = intentClient.predict(chatRequest.chatMessage()).block(); // fast-api 서버의 ai 챗봇 모델 호출
 
-        redisManager.saveMessageInRedis(customUserDetails.getMemberId(),chatRequest.chatMessage(),cleanAiResponse); // 유저 메시지,챗봇 답변 Redis에 업로드
+        /* Fast- API서버 다운 시 Gpt 모델 호출 */
+        String previousMessage  = chatBotManager.getPreviousMessage(customUserDetails.getMemberId()); // Redis DB에서 기존의 대화내용이 있으면 반환
+        String promptMessage = ChatBotHelper.makePromptMessage(chatRequest.chatMessage(), previousMessage); // 사용자 메시지를 프롬프팅
+        String rawAiResponse = chatClient.call(promptMessage); // 프로프팅한 유저의 채팅에 대한 AI 상담사 챗봇 답변 반환
+        String aiResponse = ChatBotHelper.textCleaner(rawAiResponse); // AI 상담사 챗봇의 답변에 불순물 제거
 
-        return cleanAiResponse;
+        chatBotManager.saveMessageInRedis(customUserDetails.getMemberId(),chatRequest.chatMessage(),aiResponse); // 유저 메시지,챗봇 답변 Redis에 업로드
+
+        return aiResponse;
     }
+
+      /* Fast-API AI서버의 AI 챗봇 채팅 로직 */
+//    @Override
+//    public String aiChat(CustomUserDetails customUserDetails, ChatRequest chatRequest) {
+//
+//        String aiResponse = intentClient.predict(chatRequest.chatMessage()).block(); // fast-api 서버의 ai 챗봇 모델 호출
+//        chatBotManager.saveMessageInRedis(customUserDetails.getMemberId(), chatRequest.chatMessage(),aiResponse); // 유저 메시지,챗봇 답변 Redis에 업로드
+//
+//        return aiResponse;
+//    }
 
     // ======================= 챗봇 도서 추천 로직 =========================
 
@@ -77,9 +145,9 @@ public class ChatbotServiceImpl implements ChatbotService{
     @Transactional
     public List<CompleteResponse> recommend(CustomUserDetails customUserDetails) {
 
-        String topic = redisManager.getTopicsFromMessages(customUserDetails);  // 채팅 내용에서 1개의 주제 추출
-        List<CompleteResponse> recommendations = redisManager.getBookFromAladin(topic,customUserDetails); // 알라딘에서 도서 반환 메서드 호출
-        redisManager.deleteAllMessages(customUserDetails.getMemberId()); // Redis에 저장된 모든 대화 메시지 삭제
+        String topic = chatBotManager.getTopicsFromMessages(customUserDetails);  // 채팅 내용에서 1개의 주제 추출
+        List<CompleteResponse> recommendations = chatBotManager.getBookFromAladin(topic,customUserDetails); // 알라딘에서 도서 반환 메서드 호출
+        chatBotManager.deleteAllMessages(customUserDetails.getMemberId()); // Redis에 저장된 모든 대화 메시지 삭제
 
         return recommendations;
     }


### PR DESCRIPTION
[1] Redis에 FastAPI 장애 기록(FastAPI-Error 키)이 있는지 확인
    → 있으면 GPT 모델 호출
    → 없으면 FastAPI 호출 시도

[2] FastAPI 호출 성공
    → 결과 반환

[3] FastAPI 호출 중 예외 발생
    → GPT 백업 모델 호출
    → Redis에 장애 기록 등록 (Value: 발생 시각, TTL 30분)
    → FastAPI 재시작 명령 호출 (미구현)

[4] 최종적으로 대화 내용을 Redis에 저장 후, 응답 반환
