### PR TITLE
🐛 [버그 수정] : 서버의 bash 절대경로 직접 지정하여 bash 사용 시도

### DIFF
--- a/springboot/src/main/java/bookcalendar/server/Global/ExternalConnection/Service/ConnectionService.java
+++ b/springboot/src/main/java/bookcalendar/server/Global/ExternalConnection/Service/ConnectionService.java
@@ -66,7 +66,7 @@ public class ConnectionService {
      */
     public void rerunFastApiScript() {
         try {
-            ProcessBuilder processBuilder = new ProcessBuilder("bash", SCRIPT_PATH);
+            ProcessBuilder processBuilder = new ProcessBuilder("/usr/bin/bash", SCRIPT_PATH);
             processBuilder.redirectErrorStream(true); // 에러도 출력에 함께 포함
 
             Process process = processBuilder.start();


### PR DESCRIPTION
경로 직접 지정